### PR TITLE
AB-449 Fix the release `Dockerfile.jvm`

### DIFF
--- a/operator/src/main/docker/Dockerfile.jvm
+++ b/operator/src/main/docker/Dockerfile.jvm
@@ -79,7 +79,7 @@
 #
 ###
 # https://catalog.redhat.com/en/software/containers/ubi9/openjdk-25-runtime/69204990c46419100ce30a5b
-FROM registry.redhat.io/ubi9/openjdk-25-runtime:1.24
+FROM registry.access.redhat.com/ubi9/openjdk-25-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 


### PR DESCRIPTION
The `registry.redhat.io` OCI image registry needs authentication, but `registry.access.redhat.com` does not.

```
#2 [internal] load metadata for registry.redhat.io/ubi9/openjdk-25-runtime:1.24
#2 ERROR: failed to authorize: failed to fetch anonymous token: unexpected status from GET request to https://registry.redhat.io/auth/realms/rhcc/protocol/redhat-docker-v2/auth?scope=repository%3Aubi9%2Fopenjdk-25-runtime%3Apull&service=docker-registry: 401 Unauthorized
```