### PR TITLE
AB-449 Always run the Gradle task `quarkusAppPartsBuild`

### DIFF
--- a/operator/build.gradle.kts
+++ b/operator/build.gradle.kts
@@ -71,6 +71,10 @@ tasks.quarkusDev {
     jvmArgs = listOf("--add-opens", "java.base/java.lang=ALL-UNNAMED")
 }
 
+tasks.quarkusAppPartsBuild {
+    doNotTrackState("Always execute Gradle task quarkusAppPartsBuild to generate the K8s deploy manifest kubernetes.yml and to publish the Helm chart")
+}
+
 tasks.withType<Test> {
     val mockitoAgent = configurations.testRuntimeClasspath.get().find {
         it.name.contains("mockito-core")


### PR DESCRIPTION
In the previous release, no Helm chart `*.tgz` was created as the Gradle cache was hit on this task.

https://github.com/aboutbits/postgresql-operator/actions/runs/21400942011/job/61611656938#step:11:18