### PR TITLE
Fix LICENSE file company name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright AboutBits GmbH
+Copyright About Bits GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/operator/src/main/helm/LICENSE
+++ b/operator/src/main/helm/LICENSE
@@ -1,4 +1,4 @@
-Copyright AboutBits GmbH
+Copyright About Bits GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
I don't know why, but the commit somehow did not make it into `main`, WTF GitHub.
[`128f7f9` (#13)](https://github.com/aboutbits/postgresql-operator/pull/13/commits/128f7f925a151ab7cb5e73f04fa5a0b2576093a0)

Related to https://github.com/aboutbits/postgresql-operator/pull/13#discussion_r2740915807 and https://github.com/aboutbits/postgresql-operator/pull/13#discussion_r2741009237