### PR TITLE
Fix Helm chart packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,10 @@ jobs:
         env:
           GITHUB_USER_NAME: ${{ github.actor }}
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Package Helm chart
+        run: |
+          tar -czf operator/build/helm/kubernetes/postgresql-operator-${{ steps.nextVersion.outputs.version }}.tgz -C operator/build/helm/kubernetes postgresql-operator
+        shell: bash
       - uses: aboutbits/github-actions-docker/build-push@v1
         with:
           username: ${{ github.actor }}
@@ -86,7 +90,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
         run: |
-          gh release upload v${{ steps.nextVersion.outputs.version }} operator/build/helm/kubernetes/*.tgz operator/build/kubernetes/*.postgresql.aboutbits.it-v1.yml
+          gh release upload v${{ steps.nextVersion.outputs.version }} operator/build/helm/kubernetes/postgresql-operator-${{ steps.nextVersion.outputs.version }}.tgz operator/build/kubernetes/*.postgresql.aboutbits.it-v1.yml
         shell: bash
       - name: Update README.md
         run: |

--- a/operator/src/main/resources/application.yml
+++ b/operator/src/main/resources/application.yml
@@ -70,7 +70,7 @@ quarkus:
         name: AboutBits
         email: info@aboutbits.it
         url: https://aboutbits.it/
-    create-tar-file: true
+    create-tar-file: false
     extension: tgz
     values:
       replicas:


### PR DESCRIPTION
It seems like `quarkus.helm.create-tar-file=true` does not package the additional files that are generated under `operator/build/helm/kubernetes/postgresql-operator`.

See the marked files here, which are missing in the automatically packaged `*.tgz` file:
<img width="2028" height="1234" alt="image" src="https://github.com/user-attachments/assets/5703ee04-7393-41ed-8311-96caac4f8715" />

See the files from the last release:
https://github.com/aboutbits/postgresql-operator/releases/download/v0.2.1/postgresql-operator-0.2.1.tgz

This archive contains a consolidated `clusterrolebinding.yaml`, whereas the folder `operator/build/helm/kubernetes/postgresql-operator` with `quarkus.helm.create-tar-file=false` contains a different set of role bindings, as shown in the previous screenshot.
<img width="608" height="1451" alt="image" src="https://github.com/user-attachments/assets/4d0c9df5-d1fa-4be4-890f-e8b9ab105eb8" />

Also the content is not the same:
`quarkus.helm.create-tar-file=true`
<img width="790" height="1469" alt="image" src="https://github.com/user-attachments/assets/b631bdfb-bdc3-4871-8125-18e1f9af894c" />

As the namespace is missing in the role bindings from the automatically created archive, I get this error when I install the Helm chart:
```bash
> helm install --namespace postgresql-cluster-configuration-operator postgresql-operator https://github.com/aboutbits/postgresql-operator/releases/download/v0.2.1/postgresql-operator-0.2.1.tgz
Error: INSTALLATION FAILED: 12 errors occurred:
        * ClusterRoleBinding.rbac.authorization.k8s.io "clusterconnectionreconciler-cluster-role-binding" is invalid: subjects[0].namespace: Required value
        * ClusterRoleBinding.rbac.authorization.k8s.io "schemareconciler-crd-validating-role-binding" is invalid: subjects[0].namespace: Required value
        * ClusterRoleBinding.rbac.authorization.k8s.io "databasereconciler-cluster-role-binding" is invalid: subjects[0].namespace: Required value
        * ClusterRoleBinding.rbac.authorization.k8s.io "rolereconciler-crd-validating-role-binding" is invalid: subjects[0].namespace: Required value
        * ClusterRoleBinding.rbac.authorization.k8s.io "clusterconnectionreconciler-crd-validating-role-binding" is invalid: subjects[0].namespace: Required value
        * ClusterRoleBinding.rbac.authorization.k8s.io "rolereconciler-cluster-role-binding" is invalid: subjects[0].namespace: Required value
        * ClusterRoleBinding.rbac.authorization.k8s.io "databasereconciler-crd-validating-role-binding" is invalid: subjects[0].namespace: Required value
        * ClusterRoleBinding.rbac.authorization.k8s.io "schemareconciler-cluster-role-binding" is invalid: subjects[0].namespace: Required value
        * ClusterRoleBinding.rbac.authorization.k8s.io "defaultprivilegereconciler-crd-validating-role-binding" is invalid: subjects[0].namespace: Required value
        * ClusterRoleBinding.rbac.authorization.k8s.io "grantreconciler-cluster-role-binding" is invalid: subjects[0].namespace: Required value
        * ClusterRoleBinding.rbac.authorization.k8s.io "defaultprivilegereconciler-cluster-role-binding" is invalid: subjects[0].namespace: Required value
        * ClusterRoleBinding.rbac.authorization.k8s.io "grantreconciler-crd-validating-role-binding" is invalid: subjects[0].namespace: Required value
```

The content of, for example file `operator/build/helm/kubernetes/postgresql-operator/databasereconciler-crd-role-binding.yaml`
<img width="1437" height="1391" alt="image" src="https://github.com/user-attachments/assets/c540a7ef-4a35-493f-8bd5-706fff6ab70d" />

___

Due to this, I'm disabling `quarkus.helm.create-tar-file=false` and do the `*.tgz` packaging myself.