### PR TITLE
Fix missing `RoleReconciler` `ClusterRole` secrets verbs as the reconciler is watching referenced Secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,10 @@ jobs:
         env:
           GITHUB_USER_NAME: ${{ github.actor }}
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Patch ClusterRole rolereconciler-cluster-role with secrets permission as the RoleReconciler is watching referenced Secrets
+        run: |
+          yq -i 'select(.metadata.name == "rolereconciler-cluster-role").rules += [{"apiGroups": [""], "resources": ["secrets"], "verbs": ["get", "list", "watch"]}]' operator/build/helm/kubernetes/postgresql-operator/templates/clusterrole.yaml
+        shell: bash
       - name: Package Helm chart
         run: |
           tar -czf operator/build/helm/kubernetes/postgresql-operator-${{ steps.nextVersion.outputs.version }}.tgz -C operator/build/helm/kubernetes postgresql-operator

--- a/operator/src/main/resources/application.yml
+++ b/operator/src/main/resources/application.yml
@@ -147,6 +147,16 @@ quarkus:
         memory: 300Mi
       limits:
         memory: 512Mi
+    # Report bug as this or adding the ClusterRole and ClusterRoleBinding in operator/src/main/kubernetes/kubernetes.yml does not work, JOSDK simply ignores the ClusterRoleBinding
+    #rbac:
+    #  cluster-roles:
+    #    "rolereconciler-cluster-role":
+    #      name: rolereconciler-cluster-role
+    #      policy-rules:
+    #        "secrets":
+    #          api-groups: [""]
+    #          resources: ["secrets"]
+    #          verbs: ["get", "list", "watch"]
     startup-probe:
       http-action-port-name: http
       initial-delay: PT2S


### PR DESCRIPTION
Report a Quarkus JOSDK bug as configuring the `quarkus.kubernetes.rbac.cluster-role`* properties or adding the `ClusterRole` and `ClusterRoleBinding` in `operator/src/main/kubernetes/kubernetes.yml` does not work, JOSDK simply ignores the `ClusterRoleBinding` when creating the final Helm chart, but it adds the `ClusterRole`.

See the https://quarkus.io/guides/all-config