### PR TITLE
Fix `map: map[] does not contain declared merge key: name`

### DIFF
--- a/operator/src/main/resources/application.yml
+++ b/operator/src/main/resources/application.yml
@@ -90,7 +90,7 @@ quarkus:
           - null
         paths:
           - (kind == Deployment).spec.template.spec.imagePullSecrets
-        expression: "{{- toYaml .Values.app.imagePullSecrets | nindent 8 }}"
+        expression: "{{- if eq (toYaml .Values.app.imagePullSecrets | trim) \"- {}\" }} null{{- else }}{{- toYaml .Values.app.imagePullSecrets | nindent 8 }}{{- end }}"
         description: Kubernetes image pull secrets to use if the OCI image is hosted on a private registry
       resource-requests-cpu:
         property: resources.requests.cpu

--- a/operator/src/test/java/it/aboutbits/postgresql/helm/HelmTest.java
+++ b/operator/src/test/java/it/aboutbits/postgresql/helm/HelmTest.java
@@ -1,7 +1,6 @@
 package it.aboutbits.postgresql.helm;
 
 import io.fabric8.kubernetes.api.model.ConfigBuilder;
-import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.quarkus.test.junit.QuarkusTest;
@@ -173,11 +172,8 @@ class HelmTest {
 
                     assertThat(deployment.getSpec())
                             .isNotNull()
-                            .satisfies(spec -> assertThat(spec.getTemplate().getSpec().getImagePullSecrets())
-                                    .isNotEmpty()
-                                    .element(0)
-                                    .isNotNull()
-                                    .isEqualTo(new LocalObjectReference(null))
+                            .satisfies(spec ->
+                                    assertThat(spec.getTemplate().getSpec().getImagePullSecrets()).isEmpty()
                             );
 
                     var selector = deployment.getSpec().getSelector();


### PR DESCRIPTION
I'm not particularly proud of this workaround, but it is what it is until I find a way to add a `operator/src/main/kubernetes/kubernetes.yml` `null` or `~` or `[]` value for key `spec.template.spec.imagePullSecrets` with the Quarkus Kubernetes + Helm extension that actually renders the key in the generated `kubernetes.yml` and Helm chart.

<img width="844" height="252" alt="image" src="https://github.com/user-attachments/assets/245a6dff-7524-4e06-836c-2032f7d5675a" />

I works in my local testing:
<img width="576" height="207" alt="image" src="https://github.com/user-attachments/assets/180a4c3c-cc68-4a6b-ad98-54cf8f85ba29" />