### PR TITLE
Update to Quarkus `3.34.6` and remove the manual Helm chart tar step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,10 +47,6 @@ jobs:
         env:
           GITHUB_USER_NAME: ${{ github.actor }}
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Package Helm chart
-        run: |
-          tar -czf operator/build/helm/kubernetes/postgresql-operator-${{ steps.nextVersion.outputs.version }}.tgz -C operator/build/helm/kubernetes postgresql-operator
-        shell: bash
       - uses: aboutbits/github-actions-docker/build-push@v1
         with:
           username: ${{ github.actor }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,9 +7,9 @@ org.gradle.logging.level=INFO
 
 # Quarkus
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=3.33.1
+quarkusPluginVersion=3.34.6
 # https://mvnrepository.com/artifact/io.quarkus.platform/quarkus-bom
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=3.33.1
+quarkusPlatformVersion=3.34.6
 systemProp.quarkus.analytics.disabled=true

--- a/operator/src/main/resources/application.yml
+++ b/operator/src/main/resources/application.yml
@@ -71,7 +71,7 @@ quarkus:
         name: AboutBits
         email: info@aboutbits.it
         url: https://aboutbits.it/
-    create-tar-file: false
+    create-tar-file: true
     extension: tgz
     values:
       replicas:


### PR DESCRIPTION
Related to
https://github.com/quarkiverse/quarkus-operator-sdk/issues/1260#issuecomment-4221328670 -> https://github.com/quarkiverse/quarkus-helm/pull/492
https://github.com/quarkiverse/quarkus-operator-sdk/issues/1336 -> https://github.com/quarkiverse/quarkus-operator-sdk/pull/1340

The Quarkus update also fixes the `quarkus.helm.create-tar-file=true` support for CRDs, so I can remove the manual tar step now :-)

This also fixes
https://github.com/operator-framework/java-operator-sdk/issues/3255 -> https://github.com/operator-framework/java-operator-sdk/pull/3256 