### PR TITLE
Update to Quarkus `3.35.3` and tune back the probes as a JOSDK health check issue was fixed

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,9 +7,9 @@ org.gradle.logging.level=INFO
 
 # Quarkus
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=3.34.6
+quarkusPluginVersion=3.35.3
 # https://mvnrepository.com/artifact/io.quarkus.platform/quarkus-bom
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=3.34.6
+quarkusPlatformVersion=3.35.3
 systemProp.quarkus.analytics.disabled=true

--- a/operator/src/main/resources/application.yml
+++ b/operator/src/main/resources/application.yml
@@ -168,21 +168,21 @@ quarkus:
       period: PT10S
       timeout: PT3S
       success-threshold: 1
-      failure-threshold: 20
+      failure-threshold: 3
     readiness-probe:
       http-action-port-name: http
       initial-delay: PT0S
       period: PT5S
       timeout: PT3S
       success-threshold: 1
-      failure-threshold: 20
+      failure-threshold: 3
     liveness-probe:
       http-action-port-name: http
       initial-delay: PT5S
       period: PT10S
       timeout: PT3S
       success-threshold: 1
-      failure-threshold: 20
+      failure-threshold: 3
     env:
       fields:
         KUBERNETES_NODE_NAME: spec.nodeName


### PR DESCRIPTION
As the issue https://github.com/quarkiverse/quarkus-operator-sdk/issues/1174#issuecomment-4377009838 was fixed, we can now set the probes `failureThreshold` to the original value of 3 again.

The fix was PR https://github.com/operator-framework/java-operator-sdk/pull/3209