### PR TITLE
Configure all-contributors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,16 @@
+{
+  "projectName": "postgresql-operator",
+  "projectOwner": "aboutbits",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": true,
+  "commitConvention": "angular",
+  "contributorsPerLine": 7,
+  "linkToUsage": true,
+  "skipCi": true,
+  "contributors": []
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # AboutBits PostgreSQL Operator
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 AboutBits PostgreSQL Operator is a Kubernetes operator that helps you manage PostgreSQL databases, schemas, roles (users), and privileges in a declarative way using Custom Resource Definitions (CRDs).
 
@@ -353,3 +356,16 @@ For support, please contact [info@aboutbits.it](mailto:info@aboutbits.it).
 ### License
 
 The MIT License (MIT). Please see the [license file](LICENSE) for more information.
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!


### PR DESCRIPTION
The PR #55 gave me the idea to configure https://allcontributors.org/en/ for this project.
This is not a must, but it would make contributions even more visible for the free time they have used.

I have seen this first in 2023 in this Quarkiverse repo when I reported some bugs
https://github.com/quarkiverse/quarkus-quinoa#contributors-

All Quarkiverse repos from RedHat/IBM are using this @all-contributors bot.

Usage of the bot:
https://github.com/quarkiverse/quarkus-quinoa/pull/539#issuecomment-1745412023

Outcome of the comment:
https://github.com/quarkiverse/quarkus-quinoa/pull/540

Their configuration:
https://github.com/quarkiverse/quarkus-quinoa/blob/main/.all-contributorsrc

I did not configure the bot, as the Bot would require permission for this repo from the `AboutBits` org, so I used the CLI for now and we can continue to use the CLI instead of the bot.
The initial setup in this PR is coming from the CLI, I did not change anything myself.

Bot: https://allcontributors.org/en/bot/overview/
CLI: https://allcontributors.org/en/cli/overview/

The `.all-contributorsrc` configuration (automatically generated by the CLI):
https://allcontributors.org/en/bot/configuration/

In a follow-up PR, I will add the contributors.
___

The rationale behind this:
https://github.com/all-contributors/allcontributors.org#welcome-to-the-all-contributors-website-repository

<img width="955" height="454" alt="image" src="https://github.com/user-attachments/assets/b4d3cac0-73c2-4a06-8d88-a6ca91fe93dc" />

___

<img width="601" height="873" alt="image" src="https://github.com/user-attachments/assets/d45e8c59-5958-46cb-95af-20b5d41ad0fa" />
