### PR TITLE
Enforce LF line endings with .gitattributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,5 +20,8 @@ indent_size = 2
 [Makefile*]
 indent_style = tab
 
+[*.bat]
+end_of_line = crlf
+
 [src/main/resources/default_banner.txt]
 insert_final_newline = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,13 @@
-src/generated/** linguist-generated
+# Line endings: store LF in the repository and check out LF on every platform.
+# Git detects binary files itself through text=auto. The entries below are the exceptions.
+* text=auto eol=lf
+
+# Windows batch files need CRLF in the working tree.
+*.bat text eol=crlf
+
+# Binary files
+*.jar binary
+*.png binary
+
+# GitHub: mark the jOOQ generated sources as generated (collapsed in diffs, excluded from language statistics).
+generated/src/** linguist-generated


### PR DESCRIPTION
Two files in #60 arrived with CRLF line endings although `.editorconfig` asks for LF. `.editorconfig` only advises the editor, so a different tool or git client can still commit CRLF. This PR adds the git-side rule.

- `* text=auto eol=lf`: every text file is stored with LF and checked out with LF on every platform. Git detects binary files itself.
- `*.bat text eol=crlf`: `gradlew.bat` keeps CRLF in the working tree, as the Gradle wrapper expects.
- `*.jar binary`, `*.png binary`: explicit for the two binary types in the repo.
- `[*.bat] end_of_line = crlf` in `.editorconfig`, matching the git rule.
- Fix for the `linguist-generated` pattern: the jOOQ sources live under `generated/src/`, not `src/generated/`, so the old pattern matched nothing. Verified with `git check-attr`.

`git add --renormalize .` changed no other file, so `main` has no CRLF left after #61.
